### PR TITLE
Fix issues of template/1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 - [基础结构描述](#基础结构描述)
 - [配置控制器定义](#配置控制器定义)
   - [类型：controller](#类型controller)
-    - [controller：Deployment](controllerdeployment)
-    - [controller：StatefulSet](controllerstatefulset)
-    - [controller：DaemonSet](controllerdaemonset)
-    - [controller：Job](controllerjob)
-    - [controller：CronJob](controllercronjob)
+    - [controller：Deployment](#controllerdeployment)
+    - [controller：StatefulSet](#controllerstatefulset)
+    - [controller：DaemonSet](#controllerdaemonset)
+    - [controller：Job](#controllerjob)
+    - [controller：CronJob](#controllercronjob)
   - [类型：schedule](#类型schedule)
   - [类型：pod](#类型pod)
   - [类型：initContainer，container](#类型initcontainercontainer)
@@ -433,6 +433,8 @@ _config:
   - type: StatefulSet
     controller:
       replica: 3
+      name: "asda2222"
+      domain: "asdas"
     schedule:
       labels:
         cpu: heavy
@@ -542,7 +544,7 @@ _config:
         request: 5Gi
         limit: 100Gi
     services:
-    - name: mysql
+    - name: mysql1
       type: ClusterIP
       export: true
       ports:
@@ -550,12 +552,33 @@ _config:
         targetPort: 80
         port: 80
     - name: mysql2
-      type: ClusterIP
+      type: NodePort
       export: false
       ports:
       - protocol: HTTPS
         targetPort: 443
         port: 443
+        nodePort: 31222
+  - type: Deployment
+    controller:
+      replica: 1
+    containers:
+    - image: cargo.caicloudprivatetest.com/caicloud/simplelog
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+        limits:
+          cpu: 100m
+          memory: 100Mi
+    services:
+    - name: log1
+      type: ClusterIP
+      export: true
+      ports:
+      - protocol: HTTP
+        targetPort: 80
+        port: 80
 subchart:
   _config:
     略

--- a/templates/1.0.0/templates/_helpers.tpl
+++ b/templates/1.0.0/templates/_helpers.tpl
@@ -5,9 +5,9 @@
 {{- define "fullname" -}}
   {{- $global := index . 0 -}}
   {{- $index := index . 1 -}}
-  {{- $release := $global.Release.Name | trunc 40 | trimSuffix "-" | lower -}}
-  {{- $chart := include "cid" $global -}}
-  {{- printf "%s-c%s-%d" $release $chart $index -}}
+  {{- $release := $global.Release.Name | trunc 30 | trimSuffix "-" | lower -}}
+  {{- $chart := $global.Chart.Name | trunc 20 | trimSuffix "-" | lower -}}
+  {{- printf "%s-%s-%d" $release $chart $index -}}
 {{- end -}}
 
 

--- a/templates/1.0.0/templates/_scheduler.tpl
+++ b/templates/1.0.0/templates/_scheduler.tpl
@@ -66,7 +66,7 @@ requiredDuringSchedulingIgnoredDuringExecution:
     {{- if hasKey .selector "labels" }}
     matchLabels:
     {{- range $k, $v := .selector.labels }}
-      {{ $k | quote }}: {{ $v | quote }}
+      "schedule.caicloud.io/{{ $k }}": {{ $v | quote }}
     {{- end }}
     {{- end }}
     {{- if hasKey .selector "expressions" }}
@@ -95,7 +95,7 @@ preferredDuringSchedulingIgnoredDuringExecution:
       {{- if hasKey .selector "labels" }}
       matchLabels:
       {{- range $k, $v := .selector.labels }}
-        {{ $k | quote }}: {{ $v | quote }}
+        "schedule.caicloud.io/{{ $k }}": {{ $v | quote }}
       {{- end }}
       {{- end }}
       {{- if hasKey .selector "expressions" }}

--- a/templates/1.0.0/templates/services.yaml
+++ b/templates/1.0.0/templates/services.yaml
@@ -38,7 +38,7 @@ spec:
     {{- end }}
     port: {{ .port }}
     targetPort: {{ .targetPort }}
-    {{- if eq $s.type "NodePort" -}} nodePort: {{ .nodePort }} {{- end -}}
+    {{ if eq $s.type "NodePort" -}} nodePort: {{ .nodePort }} {{- end -}}
   {{- end }}
 ---
 

--- a/templates/1.0.0/values.yaml
+++ b/templates/1.0.0/values.yaml
@@ -13,6 +13,8 @@ _config:
   - type: StatefulSet
     controller:
       replica: 3
+      name: "asda2222"
+      domain: "asdas"
     schedule:
       labels:
         cpu: heavy
@@ -130,9 +132,30 @@ _config:
         targetPort: 80
         port: 80
     - name: mysql2
-      type: ClusterIP
+      type: NodePort
       export: false
       ports:
       - protocol: HTTPS
         targetPort: 443
         port: 443
+        nodePort: 31222
+  - type: Deployment
+    controller:
+      replica: 1
+    containers:
+    - image: cargo.caicloudprivatetest.com/caicloud/simplelog
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+        limits:
+          cpu: 100m
+          memory: 100Mi
+    services:
+    - name: log1
+      type: ClusterIP
+      export: true
+      ports:
+      - protocol: HTTP
+        targetPort: 80
+        port: 80


### PR DESCRIPTION
* Fix a bug about `services.yaml`
  * When service has node port, yaml generator will drop a necessary newline .
* Use chart name to generate controller name