### PR TITLE
fix an issue about pod.host

### DIFF
--- a/templates/1.0.0/templates/_pod.tpl
+++ b/templates/1.0.0/templates/_pod.tpl
@@ -11,9 +11,11 @@ dnsPolicy: {{ .dns }}
 hostname: {{ .hostname }}
 subdomain: {{ .subdomain }}
 terminationGracePeriodSeconds: {{ .termination }}
-hostNetwork: {{ .host.network }}
-hostPID: {{ .host.pid }}
-hostIPC: {{ .host.ipc }}
+{{- with .host }}
+hostNetwork: {{ .network }}
+hostPID: {{ .pid }}
+hostIPC: {{ .ipc }}
+{{- end }}
 {{- end }}
 {{- with $controller.schedule }}
 {{- template "schedule" $controller.schedule }}


### PR DESCRIPTION
`.host.network` forces config to contain a useless empty object. Now I remove the limitation.