### PR TITLE
fix a bug of env which contains number

### DIFF
--- a/templates/1.0.0/templates/_pod.tpl
+++ b/templates/1.0.0/templates/_pod.tpl
@@ -125,7 +125,7 @@ containers:
 {{- define "env" -}}
 {{- range . }}
 - name: {{ .name }}
-  value: {{ .value }}
+  value: {{ .value | quote }}
   {{- with .from }}
   valueFrom:
     {{- if eq .type  "Config" -}}

--- a/templates/1.0.0/values.yaml
+++ b/templates/1.0.0/values.yaml
@@ -82,6 +82,8 @@ _config:
       env:
       - name: XXSS_
         value: "sd"
+      - name: Sdsaa
+        value: "10"
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
If value of env is a number, It needs quotes arround the value.