### PR TITLE
Add revision to name of generated resources

### DIFF
--- a/templates/1.0.0/templates/_helpers.tpl
+++ b/templates/1.0.0/templates/_helpers.tpl
@@ -5,9 +5,14 @@
 {{- define "fullname" -}}
   {{- $global := index . 0 -}}
   {{- $index := index . 1 -}}
+  {{- $metadata := $global.Values._config._metadata -}}
   {{- $release := $global.Release.Name | trunc 30 | trimSuffix "-" | lower -}}
   {{- $chart := $global.Chart.Name | trunc 20 | trimSuffix "-" | lower -}}
-  {{- printf "%s-%s-%d" $release $chart $index -}}
+  {{- if and $metadata (hasKey $metadata "revision") -}}
+    {{- printf "%s-%s-v%.0f-%d" $release $chart $metadata.revision $index -}}
+  {{- else -}}
+    {{- printf "%s-%s-v1-%d" $release $chart $index -}}
+  {{- end -}}
 {{- end -}}
 
 

--- a/templates/1.0.0/values.yaml
+++ b/templates/1.0.0/values.yaml
@@ -5,6 +5,7 @@ _config:
     description: "A basic template for application"
     creationTime: "2017-07-14 12:00:00"
     source: "/library/template/1.0.0"
+    revision: 1
     class: Default
     template:
       type: "template.caicloud.io/application"


### PR DESCRIPTION
- Add revision to name of generated resources
  - An example of deployment:
    - Origin name: `testrelease-chart-0`
    - Now: `testrelease-chart-v1-0`
    - The version is a revision number from `values.yaml`. If there is no field named `revision` in `_config._metadata`, defaults to 1.