### PR TITLE
fix(templates): wrong format when add env with config and secret

### DIFF
--- a/templates/1.0.0/templates/_pod.tpl
+++ b/templates/1.0.0/templates/_pod.tpl
@@ -128,11 +128,11 @@ containers:
   value: {{ .value | quote }}
   {{- with .from }}
   valueFrom:
-    {{- if eq .type  "Config" -}}
+    {{ if eq .type  "Config" -}}
     configMapKeyRef:
-    {{- else -}}
+    {{- else }}
     secretKeyRef:
-    {{- end -}}
+    {{- end }}
       name: {{ .name }}
       key: {{ .key }}
       optional: {{ .optional }}


### PR DESCRIPTION
It generates env with wrong format. Fixed.