### PR TITLE
fix(build): move temp dir to /tmp/

### DIFF
--- a/build/charts/build.sh
+++ b/build/charts/build.sh
@@ -20,7 +20,7 @@ echo "Start to build charts into $OUTPUT_DIR from $INPUT_DIR"
 echo "Template: $TEMPLATES_DIR/$TEMPLATE_VERSION"
 echo "Image domain: $IMAGE_DOMAIN"
 echo "Force update: $FORCE_UPDATE"
-tmp=${OUTPUT_DIR}_tmp
+tmp=/tmp/charts/
 templates=$TEMPLATES_DIR/$TEMPLATE_VERSION/templates
 
 function packChart() {


### PR DESCRIPTION
<!-- PR template; please answer the questions. -->

**What this PR does**
- fix(build): move temp dir to /tmp/
  Original temp directory won't be deleted when `tar` is going wrong. So move to `/tmp/`. 